### PR TITLE
feat: 사서 근무지 조회, 로그아웃 기능 추가

### DIFF
--- a/accounts/urls.py
+++ b/accounts/urls.py
@@ -6,4 +6,5 @@ app_name = 'accounts'
 urlpatterns = [
     path('user/login/', UserLoginView.as_view(), name='user-login'),       # /accounts/user/login/
     path('admin/login/', ManagerLoginView.as_view(), name='manager-login'), # /accounts/admin/login/
+    path('logout/', LogoutView.as_view(), name='logout'),                  # /accounts/logout/
 ]

--- a/accounts/views.py
+++ b/accounts/views.py
@@ -25,3 +25,12 @@ class ManagerLoginView(APIView):
         if serializer.is_valid():
             return Response(serializer.validated_data)
         return Response(serializer.errors)
+
+
+class LogoutView(APIView):
+    permission_classes = [permissions.IsAuthenticated]
+
+    def post(self, request):
+        serializer = LogoutSerializer(data={}, context={"request": request})
+        serializer.is_valid(raise_exception=True)
+        return Response(serializer.validated_data)

--- a/adminpanel/serializers.py
+++ b/adminpanel/serializers.py
@@ -1,0 +1,8 @@
+from rest_framework import serializers
+from django.conf import settings
+
+class ManagerLibrarySerializer(serializers.Serializer):
+    name = serializers.SerializerMethodField()
+    
+    def get_name(self, obj):
+        return settings.DEFAULT_MANAGER_LIBRARY_NAME

--- a/adminpanel/urls.py
+++ b/adminpanel/urls.py
@@ -4,4 +4,5 @@ from .views import *
 app_name = 'adminpanel'
 
 urlpatterns = [
+    path('library/', ManagerLibraryView.as_view(), name='manager_library'),     # /adminpanel/library/
 ]

--- a/adminpanel/views.py
+++ b/adminpanel/views.py
@@ -1,3 +1,9 @@
-from django.shortcuts import render
+from rest_framework.views import APIView
+from rest_framework.response import Response
+from rest_framework import status, permissions
+from .serializers import *
 
-# Create your views here.
+class ManagerLibraryView(APIView):
+    def get(self, request):
+        serializer = ManagerLibrarySerializer({})
+        return Response(serializer.data)

--- a/configs/settings.py
+++ b/configs/settings.py
@@ -147,3 +147,5 @@ MEDIA_ROOT = os.path.join(BASE_DIR, 'media')
 DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
 
 AUTH_USER_MODEL = 'accounts.User'
+
+DEFAULT_MANAGER_LIBRARY_NAME = "해오름 작은도서관"

--- a/configs/settings.py
+++ b/configs/settings.py
@@ -31,6 +31,7 @@ INSTALLED_APPS = [
     'corsheaders',
     'rest_framework',
     'rest_framework_simplejwt',
+    'rest_framework_simplejwt.token_blacklist',
     # 추가한 앱
     'accounts',
     'libraries',
@@ -54,6 +55,7 @@ SIMPLE_JWT = {
     'ROTATE_REFRESH_TOKENS': True,
     'AUTH_HEADER_TYPES': ('Bearer',),
     'TOKEN_USER_CLASS': 'accounts.User',
+    'BLACKLIST_AFTER_ROTATION': True
 }
 
 MIDDLEWARE = [


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 이슈 완료 전이면 close 없이 #00만 작성해주세요 -->
- close #06

## ✨ 작업 내용
<!-- 작업한 내용을 명확히 요약해주세요 (예: 기능 추가/수정/제거, 리팩토링 등) -->
- 사서 근무지 조회 기능 구현
  - `settings.py`에 근무 도서관 이름 상수 추가 (DEFAULT_MANAGER_LIBRARY_NAME = "해오름 작은도서관")
  - 토큰 인증 없이 접근 가능하도록 설정 -> 토큰 인증은 추후에 추가할 예정이나...일단은 보류하겠습니다
- 로그아웃 기능 구현
  - 로그아웃하려면 토큰 인증이 필요해서 Access Token 인증이 필요한 API로 설정 (`IsAuthenticated`)

## 📸 Postman 테스트
- 사서 근무지 조회: <img width="1378" height="660" alt="image" src="https://github.com/user-attachments/assets/b9003531-6bb7-4de3-8123-375410a77ca8" />
- 로그아웃: <img width="1383" height="635" alt="image" src="https://github.com/user-attachments/assets/7ae51f69-cf1c-4dda-9885-3be6b8beeff4" />

## ✅ 체크 리스트
- [x] main 브랜치 pull 완료
- [x] Assignees 설정
