### PR TITLE
feat: 현재 위치 + 도서관 지도 조회

### DIFF
--- a/configs/settings.py
+++ b/configs/settings.py
@@ -11,6 +11,12 @@ LIBRARY_API_KEY = env('LIBRARY_API_KEY')
 
 SECRET_KEY = 'django-insecure-dlq5p+95^+pyc*9s=048%bkortmbp4wy)x83a@o@zvl++&-#^p'
 
+
+NAVER_MAPS_CLIENT_ID = os.getenv("NAVER_MAPS_CLIENT_ID")   # X-NCP-APIGW-API-KEY-ID
+NAVER_MAPS_CLIENT_SECRET = os.getenv("NAVER_MAPS_CLIENT_SECRET")      # X-NCP-APIGW-API-KEY
+GEOCODE_CACHE_TTL = 600  # 10분 캐시(선택)
+
+
 DEBUG = True
 
 ALLOWED_HOSTS = ['localhost', '127.0.0.1']

--- a/libraries/views.py
+++ b/libraries/views.py
@@ -24,6 +24,7 @@ def fetch_lib_info_or_none(lib_code: int):
         return None
     return libs_data[0]["lib"]
 
+'''
 # 주소 반환용 이름 가져오는 api
 
 def fetch_lib_name_or_none(lib_code: int):
@@ -39,7 +40,7 @@ def fetch_lib_name_or_none(lib_code: int):
     if not libs_data:
         return None
     return libs_data[0]["lib"]["libName"]
-
+'''
 
 # 도서관 정보 확인 (간략)
 class LibrarySimpleView(APIView):

--- a/libraries/views.py
+++ b/libraries/views.py
@@ -24,6 +24,22 @@ def fetch_lib_info_or_none(lib_code: int):
         return None
     return libs_data[0]["lib"]
 
+# 주소 반환용 이름 가져오는 api
+
+def fetch_lib_name_or_none(lib_code: int):
+    params = {
+        "authKey": settings.LIBRARY_API_KEY,
+        "libCode": lib_code,
+        "format": "json",
+    }
+    res = requests.get(BASE_URL, params=params, timeout=5)
+    res.raise_for_status()
+    data = res.json()
+    libs_data = data.get("response", {}).get("libs", [])
+    if not libs_data:
+        return None
+    return libs_data[0]["lib"]["libName"]
+
 
 # 도서관 정보 확인 (간략)
 class LibrarySimpleView(APIView):

--- a/maps/models.py
+++ b/maps/models.py
@@ -1,6 +1,4 @@
 from django.db import models
 
 # Create your models here.
-
-# class LibraryLocations(models.Model):
     

--- a/maps/serializers.py
+++ b/maps/serializers.py
@@ -1,0 +1,45 @@
+from rest_framework import serializers
+
+# 개별 도서관 위치 및 혼잡도
+class LibraryItemSerializer(serializers.Serializer):
+    library_id = serializers.IntegerField()
+    lat = serializers.FloatField()
+    lng = serializers.FloatField()
+    congestion = serializers.CharField()
+    congestion_level = serializers.IntegerField()
+
+    CONGESTION_MAP = {
+        1: "여유",
+        2: "보통",
+        3: "혼잡",
+    }
+
+    def get_congestion(self, obj):
+        # obj["congestion_level"]을 문자열로 변환
+        return self.CONGESTION_MAP.get(obj.get("congestion_level"), "보통")
+
+    def to_representation(self, instance):
+        """
+        instance 예시:
+        {
+            "lib": {... data4library 응답의 lib 객체 ...},
+            "lat": 37.5663,
+            "lng": 126.9779,
+            "congestion_level": 1
+        }
+        """
+        lib = instance.get("lib", {})
+        return {
+            "id": str(lib.get("libCode") or lib.get("id") or ""),
+            "name": lib.get("libName"),
+            "lat": float(instance.get("lat")),
+            "lng": float(instance.get("lng")),
+            "congestion": self.get_congestion(instance),
+            "congestion_level": int(instance.get("congestion_level", 2)),
+        }
+
+
+# 최상위 응답
+class LibraryLocationAndCongestionResponse(serializers.Serializer):
+    user_location = serializers.DictField()  # {"lat": 37.5665, "lng": 126.9780}
+    libraries = LibraryItemSerializer(many=True)

--- a/maps/services.py
+++ b/maps/services.py
@@ -1,0 +1,85 @@
+from libraries.models import Library
+from .utils import fetch_lib_info_or_none, naver_geocoding_address_to_coords
+from django.core.cache import cache
+from typing import List, Dict, Any
+import logging
+
+logger = logging.getLogger(__name__)
+
+class LibraryService:
+    @staticmethod
+    def get_library_with_coordinates(library_code: str) -> Optional[Dict[str, Any]]:
+        """단일 도서관 정보를 좌표와 함께 가져오기"""
+        library_code = library_id
+        # 캐시 확인
+        cache_key = f"library_coords_{library_code}"
+        cached_data = cache.get(cache_key)
+        if cached_data:
+            return cached_data
+        
+        # 도서관 기본 정보 가져오기
+        lib_info = fetch_lib_info_or_none(library_code)
+        if not lib_info:
+            return None
+        
+        # 주소를 좌표로 변환
+        coordinates = None
+        if lib_info.get('address'):
+            coordinates = naver_geocoding_address_to_coords(lib_info['address'])
+        
+        if coordinates:
+            lat, lng = coordinates
+            library_data = {
+                'code': library_code,
+                'name': lib_info['name'],
+                'address': lib_info['address'],
+                'phone': lib_info.get('phone', ''),
+                'latitude': lat,
+                'longitude': lng,
+            }
+            
+            # 성공한 경우에만 캐시 저장 (1시간)
+            cache.set(cache_key, library_data, 3600)
+            return library_data
+        else:
+            logger.warning(f"주소를 좌표로 변환할 수 없음: {library_code} - {lib_info.get('address')}")
+            return None
+    
+    @staticmethod
+    def get_all_library_info_with_coords() -> List[Dict[str, Any]]:
+        """모든 도서관의 상세 정보를 가져오고 좌표도 확보"""
+        libraries = Library.objects.all()
+        library_data = []
+        
+        for library in libraries:
+            library_info = LibraryService.get_library_with_coordinates(library.library_code)
+            if library_info:
+                library_info['id'] = library.id  # DB ID 추가
+                library_data.append(library_info)
+        
+        return library_data
+    
+    @staticmethod
+    def get_libraries_with_distance(user_lat: float, user_lng: float, max_distance_km: float = 10.0) -> List[Dict[str, Any]]:
+        """사용자 위치 기반으로 거리를 계산한 도서관 목록 반환"""
+        from .utils import calculate_distance
+        
+        library_data = LibraryService.get_all_library_info_with_coords()
+        
+        # 거리 계산 및 필터링
+        nearby_libraries = []
+        for library in library_data:
+            distance = calculate_distance(
+                user_lat, user_lng,
+                library['latitude'], library['longitude']
+            )
+            
+            # 최대 거리 내의 도서관만 포함
+            if distance <= max_distance_km:
+                library['distance'] = round(distance, 2)
+                nearby_libraries.append(library)
+        
+        # 거리순 정렬
+        nearby_libraries.sort(key=lambda x: x['distance'])
+        
+        return nearby_libraries

--- a/maps/urls.py
+++ b/maps/urls.py
@@ -4,4 +4,5 @@ from .views import *
 app_name = 'maps'
 
 urlpatterns = [
+        path('nearby/', NearbyLibrariesView.as_view(), name='libraries-nearby'), 
 ]

--- a/maps/utils/geocoding.py
+++ b/maps/utils/geocoding.py
@@ -1,0 +1,36 @@
+# utils/geocoding.py
+import requests
+from django.conf import settings
+from functools import lru_cache
+
+NAVER_GEOCODE_URL = "https://maps.apigw.ntruss.com/map-geocode/v2/geocode"
+
+@lru_cache(maxsize=512)
+def geocode_query_cached(query: str):
+    """
+    네이버 지도 지오코딩 API 호출 후 결과를 캐싱하여 반환.
+    결과 형식:
+    [
+        {"x": "126.978275264", "y": "37.566642129", ...},
+        ...
+    ]
+    """
+    if not query:
+        return []
+
+    try:
+        res = requests.get(
+            NAVER_GEOCODE_URL,
+            params={"query": query},
+            headers={
+                "X-NCP-APIGW-API-KEY-ID": settings.NAVER_MAPS_CLIENT_ID,
+                "X-NCP-APIGW-API-KEY": settings.NAVER_MAPS_CLIENT_SECRET,
+            },
+            timeout=3,  # 3초 제한
+        )
+        res.raise_for_status()
+        data = res.json()
+    except requests.RequestException:
+        return []
+
+    return data.get("addresses", [])

--- a/maps/views.py
+++ b/maps/views.py
@@ -1,3 +1,26 @@
 from django.shortcuts import render
+from rest_framework.views import APIView
+from rest_framework.response import Response
+from rest_framework import status
+from django.conf import settings
+import json, time
+import redis
+
+r = redis.Redis.from_url(getattr(settings, "REDIS_URL", "redis://localhost:6379/0"))
+
+CONGESTION_MAP = { 1: "여유", 2: "보통", 3: "혼잡"}
 
 # Create your views here.
+
+class NearbyLibraries(APIView):
+    """
+    GET /libraries/nearby?lat=37.55&lng=126.93&radius=3000
+    응답: [{id, lat, lng, congestion, congestion_level}, ...]
+    """
+    def get(self, request):
+        try:
+            lat = float(request.query_params.get("lat"))
+            lng = float(request.query_params.get("lng"))
+            radius = int(request.query_params.get("radius", 3000))
+        except ( TypeError, ValueError ):
+            return Response({"detail": "lat, lng, radius 파라미터를 확인하세요."}, status=400)

--- a/maps/views.py
+++ b/maps/views.py
@@ -1,26 +1,231 @@
-from django.shortcuts import render
+# views.py
 from rest_framework.views import APIView
 from rest_framework.response import Response
 from rest_framework import status
+from django.utils.functional import cached_property
 from django.conf import settings
-import json, time
-import redis
+from concurrent.futures import ThreadPoolExecutor, as_completed
+import time
+import requests
+from json import JSONDecodeError
+import logging
 
-r = redis.Redis.from_url(getattr(settings, "REDIS_URL", "redis://localhost:6379/0"))
+from .serializers import LibraryLocationAndCongestionResponse, LibraryItemSerializer
+from libraries.models import Library
+from libraries.views import fetch_lib_name_or_none
 
-CONGESTION_MAP = { 1: "여유", 2: "보통", 3: "혼잡"}
+BASE_URL = "http://data4library.kr/api/libSrch"
 
-# Create your views here.
+def fetch_lib_info_or_none(lib_code: int):
+    """도서관 상세 정보를 가져오는 함수"""
+    try:
+        params = {
+            "authKey": settings.LIBRARY_API_KEY,
+            "libCode": lib_code,
+            "format": "json",
+        }
+        res = requests.get(BASE_URL, params=params, timeout=5)
+        res.raise_for_status()
+        data = res.json()
+        libs_data = data.get("response", {}).get("libs", [])
+        if not libs_data:
+            return None
+        return libs_data[0]["lib"]
+    except Exception as e:
+        logger.error(f"도서관 정보 조회 실패: {lib_code} - {e}")
+        return None
+from .utils.geocoding import geocode_query_cached  # 캐시 래퍼 사용
 
-class NearbyLibraries(APIView):
-    """
-    GET /libraries/nearby?lat=37.55&lng=126.93&radius=3000
-    응답: [{id, lat, lng, congestion, congestion_level}, ...]
-    """
-    def get(self, request):
+logger = logging.getLogger(__name__)
+
+NAVER_GEOCODE_URL = "https://maps.apigw.ntruss.com/map-geocode/v2/geocode"
+WORKERS = 6
+TOTAL_TIME_BUDGET = 7.0  # 전체 응답 타임 박스(초)
+
+def fetch_lib_location_by_name(name: str, use_cache: bool = True):
+    """이름으로 지오코딩해서 (lat, lng) 반환. 캐시 우선."""
+    if not name:
+        logger.warning(f"지오코딩 실패: 이름이 없음 - {name}")
+        return None
+
+    # 1) 캐시 먼저
+    if use_cache:
         try:
-            lat = float(request.query_params.get("lat"))
-            lng = float(request.query_params.get("lng"))
-            radius = int(request.query_params.get("radius", 3000))
-        except ( TypeError, ValueError ):
-            return Response({"detail": "lat, lng, radius 파라미터를 확인하세요."}, status=400)
+            results = geocode_query_cached(name) or []
+            if results:
+                x = float(results[0]["x"])  # lng
+                y = float(results[0]["y"])  # lat
+                logger.info(f"캐시에서 지오코딩 성공: {name} -> ({y}, {x})")
+                return y, x
+        except Exception as e:
+            logger.warning(f"캐시 지오코딩 실패: {name} - {e}")
+
+    # 2) 네이버 직접 호출 (빠른 타임아웃)
+    try:
+        res = requests.get(
+            NAVER_GEOCODE_URL,
+            params={"query": name},
+            headers={
+                "X-NCP-APIGW-API-KEY-ID": settings.NAVER_MAPS_CLIENT_ID,
+                "X-NCP-APIGW-API-KEY": settings.NAVER_MAPS_CLIENT_SECRET,
+            },
+            timeout=2,  # 🔹빠르게 실패
+        )
+        res.raise_for_status()
+        data = res.json()
+        logger.info(f"네이버 API 응답: {name} - status: {res.status_code}")
+    except (requests.RequestException, JSONDecodeError) as e:
+        logger.error(f"네이버 API 요청 실패: {name} - {e}")
+        return None
+
+    addrs = data.get("addresses", [])
+    if not addrs:
+        logger.warning(f"네이버 API 주소 없음: {name}")
+        return None
+
+    first = addrs[0]
+    x = first.get("x") or (first.get("point") or {}).get("x")
+    y = first.get("y") or (first.get("point") or {}).get("y")
+    if x is None or y is None:
+        logger.warning(f"네이버 API 좌표 없음: {name} - x:{x}, y:{y}")
+        return None
+
+    logger.info(f"네이버 지오코딩 성공: {name} -> ({float(y)}, {float(x)})")
+    return float(y), float(x)
+
+
+def infer_congestion_level(lib_code: int) -> int:
+    return 2  # TODO 실제 로직으로 교체
+
+
+def congestion_level_to_text(level: int) -> str:
+    """congestion_level을 문자열로 변환"""
+    mapping = {1: "여유", 2: "보통", 3: "혼잡"}
+    return mapping.get(level, "보통")
+
+
+class NearbyLibrariesView(APIView):
+    """
+    GET /maps/nearby/?lat=..&lng=..&lib_codes=1,2,3&limit=20&force_direct=0
+    """
+    class BadRequest(Exception): ...
+
+    @cached_property
+    def user_latlng(self):
+        try:
+            lat = float(self.request.query_params.get("lat"))
+            lng = float(self.request.query_params.get("lng"))
+        except (TypeError, ValueError):
+            raise self.BadRequest("lat,lng 쿼리파라미터가 필요합니다.")
+        return {"lat": lat, "lng": lng}
+
+    def get_lib_queryset(self):
+        codes_param = self.request.query_params.get("lib_codes")
+        limit = int(self.request.query_params.get("limit", 50))
+        qs = Library.objects.all()
+        if codes_param:
+            code_list = [c.strip() for c in codes_param.split(",") if c.strip()]
+            qs = qs.filter(lib_code__in=code_list)
+        return qs[:limit]
+
+    def build_library_item(self, lib: Library, force_direct: bool = False):
+        """API 명세서에 맞는 dict 구성."""
+        logger.info(f"도서관 처리 시작: {lib.lib_code}")
+        
+        # 1차: 도서관 상세 정보 가져오기
+        lib_info = fetch_lib_info_or_none(lib.lib_code)
+        if not lib_info:
+            logger.error(f"도서관 정보 조회 실패: {lib.lib_code}")
+            return None
+        
+        # 도서관 이름 추출
+        lib_name = lib_info.get("libName")
+        if not lib_name:
+            logger.warning(f"도서관 이름이 없음: {lib.lib_code}")
+            lib_name = f"도서관_{lib.lib_code}"
+        
+        logger.info(f"도서관 정보 조회 성공: {lib.lib_code} - {lib_name}")
+
+        # 도서관 이름으로 지오코딩 (주소가 있으면 주소 우선 사용)
+        address = lib_info.get("address")
+        geocode_query = address if address else lib_name
+        
+        logger.info(f"지오코딩 쿼리: {lib.lib_code} - '{geocode_query}' (address: {bool(address)})")
+        coords = fetch_lib_location_by_name(geocode_query, use_cache=(not force_direct))
+        if not coords:
+            logger.error(f"지오코딩 실패: {lib.lib_code} - {lib_name}")
+            return None
+
+        lat, lng = coords
+        level = infer_congestion_level(lib.lib_code)
+        congestion_text = congestion_level_to_text(level)
+
+        # API 명세서에 맞는 형태로 반환
+        result = {
+            "id": str(lib.lib_code),  # 문자열로 변환
+            "lat": lat,
+            "lng": lng,
+            "congestion": congestion_text,
+            "congestion_level": level,
+        }
+        
+        logger.info(f"도서관 처리 성공: {lib.lib_code} -> {result}")
+        return result
+
+    def build_library_item_safe(self, lib: Library, force_direct: bool = False):
+        try:
+            return self.build_library_item(lib, force_direct=force_direct)
+        except Exception as e:
+            logger.error(f"도서관 처리 중 예외 발생: {lib.lib_code} - {e}")
+            return None
+
+    def get(self, request):
+        start = time.perf_counter()
+        try:
+            user_loc = self.user_latlng
+            libraries_qs = self.get_lib_queryset()
+            force_direct = request.query_params.get("force_direct") in ("1", "true", "True")
+
+            logger.info(f"요청 처리 시작 - 총 {libraries_qs.count()}개 도서관")
+            
+            items = []
+            futures = []
+
+            with ThreadPoolExecutor(max_workers=WORKERS) as ex:
+                for lib in libraries_qs:
+                    futures.append(ex.submit(self.build_library_item_safe, lib, force_direct))
+
+                # 전체 타임박스 내에서만 수거
+                completed_count = 0
+                for fut in as_completed(futures, timeout=TOTAL_TIME_BUDGET):
+                    if time.perf_counter() - start > TOTAL_TIME_BUDGET:
+                        logger.warning("시간 초과로 중단")
+                        break
+                    try:
+                        item = fut.result(timeout=1.0)
+                        completed_count += 1
+                        if item:
+                            items.append(item)
+                    except Exception as e:
+                        logger.error(f"Future 결과 처리 실패: {e}")
+
+            logger.info(f"처리 완료: {completed_count}개 처리, {len(items)}개 성공")
+
+            payload = {
+                "user_location": {"lat": user_loc["lat"], "lng": user_loc["lng"]},
+                "libraries": items,
+            }
+            
+            # Serializer 사용하지 않고 직접 반환 (디버깅용)
+            # serializer = LibraryLocationAndCongestionResponse(payload, context={"request": request})
+            # return Response(serializer.data, status=status.HTTP_200_OK)
+            
+            return Response(payload, status=status.HTTP_200_OK)
+
+        except self.BadRequest as e:
+            return Response({"error": str(e)}, status=status.HTTP_400_BAD_REQUEST)
+        except requests.RequestException as e:
+            return Response({"error": f"지오코딩 오류: {e}"}, status=status.HTTP_502_BAD_GATEWAY)
+        except Exception as e:
+            logger.error(f"예상치 못한 오류: {e}")
+            return Response({"error": "서버 오류"}, status=status.HTTP_500_INTERNAL_SERVER_ERROR)


### PR DESCRIPTION
## 📌 관련 이슈
<!-- 이슈 완료 전이면 close 없이 #00만 작성해주세요 -->
- close #00

## ✨ 작업 내용
<!-- 작업한 내용을 명확히 요약해주세요 (예: 기능 추가/수정/제거, 리팩토링 등) -->
- maps/serializer : 도서관별 위도, 경도 정보 serializer, 도서관 전체 정보 + 사용자 위치 정보 담는 최상위 serializer 생성
- maps/views.py: 
1. 도서관 코드를 통해 api를 호출, 도서관 상세 정보를 가져옴. 거기에서 이름을 추출해 네이버 지도 api를 사용해 좌표를 추출하여 담음.
2. 49번째 줄 캐시 먼저 항목의 경우: 도서관 주소 정보가 db에 담겨 있을 경우 직접 지오코딩하여 반환하는 건데 현재는 안 쓰긴 함. 그래도 api 호출 제한 개수가 있어서... 혹시 몰라서 넣어둠..
3. def infer_congestion_level을 통해 혼잡도 계산 함수명을 만들어는 둠. 이후 실제 로직으로 교체 필요
- maps/utlis/geocoding.py : 도서관 위치를 가져와 위도, 경도 좌표로 변환하는 함수. 도서관 주소 정보가 db에 담겨있을 경우 사용

## 📸 Postman 테스트
<!-- 이미지 첨부 -->
<img width="862" height="719" alt="image" src="https://github.com/user-attachments/assets/d4197c8f-975f-4d0a-990d-6b5a39240a8c" />


## ✅ 체크 리스트
- [] main 브랜치 pull 완료
- [] Assignees 설정
